### PR TITLE
Fix issue on some system with right to extract the file if downloaded…

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -18,6 +18,7 @@ directory "#{node['mattermost']['config']['install_path']}/mattermost" do
 end
 
 tar_extract node['mattermost']['package']['url'] do
+  download_dir node['mattermost']['config']['install_path']
   target_dir node['mattermost']['config']['install_path']
   checksum node['mattermost']['package']['checksum']
   user node['mattermost']['config']['user']


### PR DESCRIPTION
Hello,
I use knife solo (and so chef-solo) to deploy this cookbook. But since it as change from ark to tar_extract, I got an issue with the extract part. To fix it, I just say where to download the archive (for now in the install_path).

I don't know if it's specific to solo mode or not, but I assume it's possible it impact some other people, so here is the fix.