### PR TITLE
support for 5.17.0, Postgres, DataSourceReplicas, and a few missing directories

### DIFF
--- a/attributes/app.rb
+++ b/attributes/app.rb
@@ -159,7 +159,7 @@ default['mattermost']['app']['notification_log_settings'] = {
   'enable_file' => true,
   'file_level' => 'INFO',
   'file_json' => true,
-  'file_location' => '',
+  'file_location' => '/var/log/mattermost',
 }
 
 default['mattermost']['app']['log_settings'] = {
@@ -169,7 +169,7 @@ default['mattermost']['app']['log_settings'] = {
   'enable_file' => true,
   'file_level' => 'INFO',
   'file_json' => true,
-  'file_location' => '',
+  'file_location' => '/var/log/mattermost',
   'enable_webhook_debugging' => true,
   'enable_diagnostics' => true,
 }

--- a/attributes/app.rb
+++ b/attributes/app.rb
@@ -82,6 +82,7 @@ default['mattermost']['app']['service_settings'] = {
   'enable_bot_account_creation' => false,
   'disable_bots_when_owner_is_deactivated' => true,
   'trusted_proxy_ip_header' => [],
+  'enable_latex' => true,
 }
 default['mattermost']['app']['image_proxy_settings'] = {
   'enable_image_proxy' => true,
@@ -135,7 +136,7 @@ default['mattermost']['app']['client_requirements'] = {
 
 default['mattermost']['app']['sql_settings'] = {
   'driver_name' => 'mysql',
-  'address' => 'dockerhost',
+  'address' => 'localhost',
   'port' => '3306',
   'username' => 'mmuser',
   'password' => 'mostest',
@@ -146,7 +147,7 @@ default['mattermost']['app']['sql_settings'] = {
   'max_idle_conns' => 20,
   'max_open_conns' => 300,
   'trace' => false,
-  'at_rest_encrypt_key' => '', # SET THIS!
+  'at_rest_encrypt_key' => '',
   'query_timeout' => 30,
   'enable_public_channels_materialization' => true,
 }
@@ -215,7 +216,7 @@ default['mattermost']['app']['email_settings'] = {
   'enable_smtp_auth' => false,
   'smtp_username' => '',
   'smtp_password' => '',
-  'smtp_server' => 'dockerhost',
+  'smtp_server' => 'localhost',
   'smtp_port' => '2500',
   'connection_security' => '',
   'invite_salt' => '', # SET THIS!
@@ -371,7 +372,7 @@ default['mattermost']['app']['saml_settings'] = {
 }
 
 default['mattermost']['app']['native_app_settings'] = {
-  'app_download_link' => 'https://about.mattermost.com/downloads/',
+  'app_download_link' => 'https://mattermost.com/download/#mattermostApps',
   'android_app_download_link' => 'https://about.mattermost.com/mattermost-android-app/',
   'ios_app_download_link' => 'https://about.mattermost.com/mattermost-ios-app/',
 }
@@ -418,7 +419,7 @@ default['mattermost']['app']['webrtc_settings'] = {
 }
 
 default['mattermost']['app']['elastic_search_settings'] = {
-  'connection_url' => 'http://dockerhost:9200',
+  'connection_url' => 'http://localhost:9200',
   'username' => 'elastic',
   'password' => 'changeme',
   'enable_indexing' => false,
@@ -470,6 +471,8 @@ default['mattermost']['app']['plugin_settings'] = {
   'enable_health_check' => true,
   'plugins' => {},
   'plugin_states' => {},
+  'emable_marketplace' => true,
+  'marketplace_url' => 'https://marketplace.integrations.mattermost.com',
 }
 
 default['mattermost']['app']['cluster_Settings'] = {
@@ -480,4 +483,11 @@ default['mattermost']['app']['cluster_Settings'] = {
 
 default['mattermost']['app']['compliance_Settings'] = {
   'sign_request' => '',
+}
+
+default['mattermost']['app']['guest_account_settings']= {
+  'enable' => false,
+  'allow_email_accounts' => true,
+  'enforce_multifactor_authentication' => false,
+  'restrict_creation_to_domains' => true,
 }

--- a/attributes/mattermost.rb
+++ b/attributes/mattermost.rb
@@ -1,6 +1,6 @@
 default['mattermost']['package'] = {
-  'url' => 'https://releases.mattermost.com/5.15.1/mattermost-5.15.1-linux-amd64.tar.gz',
-  'checksum' => 'ebc868babd2bbc129dc58e8dcaff93915cdd8c684e31e162ae8cd4d6514cc30e',
+  'url' => 'https://releases.mattermost.com/5.17.0/mattermost-5.17.0-linux-amd64.tar.gz',
+  'checksum' => '70ff31b26126073674c84506293d6550bbb07118f8e6bd90aaa55dd9045fd86a',
 }
 
 default['mattermost']['config'] = {

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -37,7 +37,33 @@ directory node['mattermost']['config']['data_dir'] do
   action :create
 end
 
+
+directory node['mattermost']['app']['file_settings']['directory'] do
+  owner node['mattermost']['config']['user']
+  group node['mattermost']['config']['user']
+  mode 0755
+  recursive true
+  action :create
+end
+
+
 directory "#{install_directory}/#{node['mattermost']['app']['plugin_settings']['client_directory']}" do
+  owner node['mattermost']['config']['user']
+  group node['mattermost']['config']['user']
+  mode 0755
+  recursive true
+  action :create
+end
+
+directory node['mattermost']['app']['log_settings']['file_location'] do
+  owner node['mattermost']['config']['user']
+  group node['mattermost']['config']['user']
+  mode 0755
+  recursive true
+  action :create
+end
+
+directory node['mattermost']['app']['notification_log_settings'] do
   owner node['mattermost']['config']['user']
   group node['mattermost']['config']['user']
   mode 0755

--- a/templates/default/config.json.erb
+++ b/templates/default/config.json.erb
@@ -40,7 +40,6 @@
         "CorsExposedHeaders": "<%= node['mattermost']['app']['service_settings']['cors_exposed_headers'] %>",
         "CorsAllowCredentials": <%= node['mattermost']['app']['service_settings']['cors_allow_credentials'] %>,
         "CorsDebug": <%= node['mattermost']['app']['service_settings']['cors_debug'] %>,
-        "CorsAllowCredentials": <%= node['mattermost']['app']['service_settings']['allow_cookies_for_subdomains'] %>,
         "AllowCookiesForSubdomains": <%= node['mattermost']['app']['service_settings']['allow_cookies_for_subdomains'] %>,
         "SessionLengthWebInDays": <%= node['mattermost']['app']['service_settings']['session_length_web_in_days'] %>,
         "SessionLengthMobileInDays": <%= node['mattermost']['app']['service_settings']['session_length_mobile_in_days'] %>,
@@ -82,7 +81,8 @@
         "DisableLegacyMFA": <%= node['mattermost']['app']['service_settings']['disable_legacy_mfa'] %>,
         "EnableBotAccountCreation": <%= node['mattermost']['app']['service_settings']['enable_bot_account_creation'] %>,
         "DisableBotsWhenOwnerIsDeactivated": <%= node['mattermost']['app']['service_settings']['disable_bots_when_owner_is_deactivated'] %>,
-        "TrustedProxyIPHeader": <%= node['mattermost']['app']['service_settings']['trusted_proxy_ip_header'] %>
+        "TrustedProxyIPHeader": <%= node['mattermost']['app']['service_settings']['trusted_proxy_ip_header'] %>,
+        "EnableLatex": <%= node['mattermost']['app']['service_settings']['enable_latex'] %>
     },
     "ImageProxySettings": {
         "Enable": <%= node['mattermost']['app']['image_proxy_settings']['enable_image_proxy'] %>,
@@ -137,7 +137,7 @@
 <% replica_count = node['mattermost']['app']['sql_settings']['data_source_replicas'].count %>
 <% if (node['mattermost']['app']['sql_settings']['driver_name']=='postgres') %>
         "DataSource": "postgres://<%= node['mattermost']['app']['sql_settings']['username'] %>:<%= node['mattermost']['app']['sql_settings']['password'] %>@<%= node['mattermost']['app']['sql_settings']['address'] %>:<%= node['mattermost']['app']['sql_settings']['port'] %>/<%= node['mattermost']['app']['sql_settings']['database_name'] %>?sslmode=disable&connect_timeout=10",
-        "DataSourceReplicas": [
+        "DataSourceReplicas": [ 
     <%- node['mattermost']['app']['sql_settings']['data_source_replicas'].each_with_index do |replica, i| %>
         <% if (i < ( replica_count - 1 )) %>
         <% Chef::Log.info("Iterator is #{i}") %>
@@ -336,7 +336,8 @@
     "ComplianceSettings": {
         "Enable": <%= node['mattermost']['app']['compliance_settings']['enable'] %>,
         "Directory": "<%= node['mattermost']['app']['compliance_settings']['directory'] %>",
-        "EnableDaily": <%= node['mattermost']['app']['compliance_settings']['enable_daily'] %>
+        "EnableDaily": <%= node['mattermost']['app']['compliance_settings']['enable_daily'] %>,
+        "SignRequest":"<%= node['mattermost']['app']['compliance_Settings']['sign_request'] %>"
     },
     "LocalizationSettings": {
         "DefaultServerLocale": "<%= node['mattermost']['app']['localization_settings']['default_server_locale'] %>",
@@ -386,7 +387,10 @@
         "StreamingPort": <%= node['mattermost']['app']['cluster_settings']['streaming_port'] %>,
         "MaxIdleConns": <%= node['mattermost']['app']['cluster_settings']['max_idle_conns'] %>,
         "MaxIdleConnsPerHost": <%= node['mattermost']['app']['cluster_settings']['max_idle_conns_per_host'] %>,
-        "IdleConnTimeoutMilliseconds": <%= node['mattermost']['app']['cluster_settings']['idle_conn_timeout_milliseconds'] %>
+        "IdleConnTimeoutMilliseconds": <%= node['mattermost']['app']['cluster_settings']['idle_conn_timeout_milliseconds'] %>,
+        "NetworkInterface": "<%= node['mattermost']['app']['cluster_Settings']['network_interface'] %>",
+        "BindAddress": "<%= node['mattermost']['app']['cluster_Settings']['bind_address'] %>",
+        "AdvertiseAddress":"<%= node['mattermost']['app']['cluster_Settings']['advertise_address'] %>"
     },
     "MetricsSettings": {
         "Enable": <%= node['mattermost']['app']['metrics_settings']['enable'] %>,
@@ -455,15 +459,6 @@
         "RunJobs": <%= node['mattermost']['app']['job_settings']['run_jobs'] %>,
         "RunScheduler": <%= node['mattermost']['app']['job_settings']['run_scheduler'] %>
     },
-    "ClusterSettings": {
-        "NetworkInterface": "<%= node['mattermost']['app']['cluster_Settings']['network_interface'] %>",
-        "BindAddress": "<%= node['mattermost']['app']['cluster_Settings']['bind_address'] %>",
-        "AdvertiseAddress":"<%= node['mattermost']['app']['cluster_Settings']['advertise_address'] %>"
-    },
-    "ComplianceSettings": {
-        "SignRequest":"<%= node['mattermost']['app']['compliance_Settings']['sign_request'] %>"
-    },
-
     "PluginSettings": {
         "Enable": <%= node['mattermost']['app']['plugin_settings']['enable'] %>,
         "EnableUploads": <%= node['mattermost']['app']['plugin_settings']['enable_uploads'] %>,
@@ -471,6 +466,14 @@
         "ClientDirectory": "./<%= node['mattermost']['app']['plugin_settings']['client_directory'] %>",
         "EnableHealthCheck": <%= node['mattermost']['app']['plugin_settings']['enable_health_check'] %>,
         "Plugins": <%= require 'json'; node['mattermost']['app']['plugin_settings']['plugins'].to_json %>,
-        "PluginStates": <%= require 'json'; node['mattermost']['app']['plugin_settings']['plugin_states'].to_json %>
+        "PluginStates": <%= require 'json'; node['mattermost']['app']['plugin_settings']['plugin_states'].to_json %>,
+        "EnableMarketplace": <%= require 'json'; node['mattermost']['app']['plugin_settings']['emable_marketplace'] %>,
+        "MarketplaceUrl": "<%= node['mattermost']['app']['plugin_settings']['marketplace_url'] %>"
+    },
+    "GuestAccountsSettings": {
+        "Enable":  <%= node['mattermost']['app']['guest_account_settings']['enable'] %>,
+        "AllowEmailAccounts":  <%= node['mattermost']['app']['guest_account_settings']['allow_email_accounts'] %>,
+        "EnforceMultifactorAuthentication":  <%= node['mattermost']['app']['guest_account_settings']['enforce_multifactor_authentication'] %>,
+        "RestrictCreationToDomains":  <%= node['mattermost']['app']['guest_account_settings']['restrict_creation_to_domains'] %>
     }
 }

--- a/templates/default/config.json.erb
+++ b/templates/default/config.json.erb
@@ -134,8 +134,31 @@
     },
     "SqlSettings": {
         "DriverName": "<%= node['mattermost']['app']['sql_settings']['driver_name'] %>",
-        "DataSource": "<%= node['mattermost']['database']['username'] %>:<%= node['mattermost']['database']['password'] %>@tcp(<%= node['mattermost']['database']['address'] %>:<%= node['mattermost']['database']['port'] %>)/<%= node['mattermost']['database']['name'] %>?charset=utf8mb4,utf8&readTimeout=30s&writeTimeout=30s",
-        "DataSourceReplicas": <%= node['mattermost']['app']['sql_settings']['data_source_replicas'] %>,
+<% replica_count = node['mattermost']['app']['sql_settings']['data_source_replicas'].count %>
+<% if (node['mattermost']['app']['sql_settings']['driver_name']=='postgres') %>
+        "DataSource": "postgres://<%= node['mattermost']['app']['sql_settings']['username'] %>:<%= node['mattermost']['app']['sql_settings']['password'] %>@<%= node['mattermost']['app']['sql_settings']['address'] %>:<%= node['mattermost']['app']['sql_settings']['port'] %>/<%= node['mattermost']['app']['sql_settings']['database_name'] %>?sslmode=disable&connect_timeout=10",
+        "DataSourceReplicas": [
+    <%- node['mattermost']['app']['sql_settings']['data_source_replicas'].each_with_index do |replica, i| %>
+        <% if (i < ( replica_count - 1 )) %>
+        <% Chef::Log.info("Iterator is #{i}") %>
+            "postgres://<%= node['mattermost']['app']['sql_settings']['username'] %>:<%= node['mattermost']['app']['sql_settings']['password'] %>@<%= replica %>:<%= node['mattermost']['app']['sql_settings']['port'] %>/<%= node['mattermost']['app']['sql_settings']['database_name'] %>?sslmode=disable&connect_timeout=10",
+        <% else %>
+            "postgres://<%= node['mattermost']['app']['sql_settings']['username'] %>:<%= node['mattermost']['app']['sql_settings']['password'] %>@<%= replica %>:<%= node['mattermost']['app']['sql_settings']['port'] %>/<%= node['mattermost']['app']['sql_settings']['database_name'] %>?sslmode=disable&connect_timeout=10"
+        <% end %>
+    <%- end %>
+        ],
+<% elsif (node['mattermost']['app']['sql_settings']['driver_name']=='mysql') %>
+        "DataSource": "<%= node['mattermost']['app']['sql_settings']['username'] %>:<%= node['mattermost']['app']['sql_settings']['password'] %>@tcp(<%= node['mattermost']['app']['sql_settings']['address'] %>:<%= node['mattermost']['app']['sql_settings']['port'] %>)/<%= node['mattermost']['app']['sql_settings']['name'] %>?charset=utf8mb4,utf8&readTimeout=30s&writeTimeout=30s",
+    <%- node['mattermost']['app']['sql_settings']['data_source_replicas'].each_with_index do |replica, i| %>
+        "DataSourceReplicas": [
+        <% if (i < ( replica_count - 1 )) %>
+            "<%= node['mattermost']['app']['sql_settings']['username'] %>:<%= node['mattermost']['app']['sql_settings']['password'] %>@tcp(<%= replica %>:<%= node['mattermost']['app']['sql_settings']['port'] %>)/<%= node['mattermost']['app']['sql_settings']['name'] %>?charset=utf8mb4,utf8&readTimeout=30s&writeTimeout=30s",
+        <% else %>
+            "<%= node['mattermost']['app']['sql_settings']['username'] %>:<%= node['mattermost']['app']['sql_settings']['password'] %>@tcp(<%= replica %>:<%= node['mattermost']['app']['sql_settings']['port'] %>)/<%= node['mattermost']['app']['sql_settings']['name'] %>?charset=utf8mb4,utf8&readTimeout=30s&writeTimeout=30s"
+        <% end %>
+    <%- end %>
+        ],
+<% end %>
         "DataSourceSearchReplicas": <%= node['mattermost']['app']['sql_settings']['data_source_search_replicas'] %>,
         "MaxIdleConns": <%= node['mattermost']['app']['sql_settings']['max_idle_conns'] %>,
         "ConnMaxLifetimeMilliseconds": <%= node['mattermost']['app']['sql_settings']['conn_max_lifetime_milliseconds'] %>,


### PR DESCRIPTION
This set of changes comes with
1. properly formatted PostgreSQL db connection strings
2. support for read replicas from an array.  
3. deduplication of some config sections that had some settings in one spot and others in another section.
4. 5.17.0 release hash and link as well as attributes for this release and template config parts sourcing those.
5. creation of directories that are specified by attributes and therefore variable in location such as the file location, the log file, and the notification log file directories.